### PR TITLE
Refactor recommendation logic into separate class

### DIFF
--- a/backend/flaskr/app.py
+++ b/backend/flaskr/app.py
@@ -4,8 +4,7 @@ from flask import Flask, request
 from flask_cors import CORS
 from backend.flaskr.authentication_utils import authenticate_user, register_user
 from backend.flaskr.database_utils import DBConnection
-from backend.flaskr.yelp_api_utils import YelpAPI
-from backend.flaskr.restaurant_cache import RestaurantCache
+from backend.flaskr.recommender import Recommender
 
 # Instantiate app
 app = Flask(__name__)
@@ -14,11 +13,8 @@ CORS(app)
 # Configure DB connection
 DBConnection.setup(app)
 
-# Instantiate the YelpAPI
-yelp = YelpAPI()
-
-# Instantiate cache to prevent redundant suggestions
-cache = RestaurantCache()
+# Instantiate the recommender to generate suggestions
+recommender = Recommender()
 
 
 @app.route('/login', methods=["POST"])
@@ -42,36 +38,17 @@ def restaurants():
     """Parse the user's restaurant request and get restaurants from Yelp"""
     args = request.json.split('\n')
     user = args[0]
-    food = args[1]
-    price = args[2]
-    dist = args[3]
-    loc = (args[4], args[5])
+    search_params = {
+        "food": args[1],
+        "price": args[2],
+        "distance": args[3],
+        "location": (args[4], args[5])
+    }
 
-    print(user, food, price, dist, loc)
-
-    result = yelp.business_search(term=food, location=loc, radius=dist, price=price)
-    if result["businesses"]:
-        for restaurant in result["businesses"]:
-            if not cache.is_cached(user, restaurant["id"]):
-                cache.add_restaurant(user, restaurant["id"])
-                return {"result": {
-                    "id": restaurant["id"],
-                    "Name": restaurant["name"],
-                    "Location": restaurant["location"],
-                    "Distance": round(restaurant["distance"] / 1609.34, ndigits=1),
-                    "Price": restaurant["price"],
-                    "Rating": restaurant["rating"]
-                }}
-
-    # We exhausted all the available restaurants or there were none at all
-    print("Could not find any restaurants with the given parameters!")
-    return {"result": {
-        "id": "N/A",
-        "Name": "No matches found!",
-        "Distance": "I would walk 500",
-        "Price": "$$$$",
-        "Rating": 5
-    }}
+    print(user, search_params)
+    return {
+        "result": recommender.get_restaurant(user, search_params)
+    }
 
 
 @app.route('/rate_suggestion', methods=["POST"])
@@ -83,6 +60,8 @@ def rate_suggestion():
     rest_id = args[2]
 
     print(user, rating, rest_id)
-    # Send data to the user's model for training
+    
+    # Send data to the user's model for training and cache the reviewed restaurant
+    recommender.cache_restaurant(user, rest_id)
 
     return {'result': "TODO"}

--- a/backend/flaskr/app.py
+++ b/backend/flaskr/app.py
@@ -60,7 +60,7 @@ def rate_suggestion():
     rest_id = args[2]
 
     print(user, rating, rest_id)
-    
+
     # Send data to the user's model for training and cache the reviewed restaurant
     recommender.cache_restaurant(user, rest_id)
 

--- a/backend/flaskr/recommender.py
+++ b/backend/flaskr/recommender.py
@@ -17,7 +17,7 @@ class Recommender:
         """
         self.yelp = YelpAPI()
         self.cache = RestaurantCache(cache_timeout)
- 
+
     def get_restaurant(self, user, search_params):
         """
         Suggest a restaurant to the user based on their search criteria

--- a/backend/flaskr/recommender.py
+++ b/backend/flaskr/recommender.py
@@ -12,7 +12,6 @@ class Recommender:
         """
         Initializes restaurant cache and Yelp API to get suggestions and
         maintain which restaurants have been recently rated.
-
         :param cache_timeout: Number of seconds to maintain stale restaurnt entries in cache
         :return: None
         """

--- a/backend/flaskr/recommender.py
+++ b/backend/flaskr/recommender.py
@@ -1,0 +1,64 @@
+"""Class to generate restaurant recommendations for a user"""
+
+from backend.flaskr.yelp_api_utils import YelpAPI
+from backend.flaskr.restaurant_cache import RestaurantCache
+
+class Recommender:
+    """
+    Class to generate restaurant recommendations for a user from the Yelp API
+    """
+
+    def __init__(self, cache_timeout=86400):
+        """
+        Initializes restaurant cache and Yelp API to get suggestions and maintain which have been recently rated
+        :param cache_timeout: Number of seconds to maintain stale restaurnt entries in cache
+        :return: None
+        """
+        self.yelp = YelpAPI()
+        self.cache = RestaurantCache(cache_timeout)
+ 
+    def get_restaurant(self, user, search_params):
+        """
+        Suggest a restaurant to the user based on their search criteria
+        :param user: User's for which we're suggesting a restaurant
+        :param search_params: Dictionary of parameters used in Yelp search
+        :return: Restaurant object
+        """
+        food = search_params["food"]
+        location = search_params["location"]
+        distance = search_params["distance"]
+        price = search_params["price"]
+
+        result = self.yelp.business_search(term=food, location=location, radius=distance, price=price)
+
+        if "businesses" in result:
+            for restaurant in result["businesses"]:
+                if not self.cache.is_cached(user, restaurant["id"]):
+                    return {
+                        "id": restaurant["id"],
+                        "Name": restaurant["name"],
+                        "Location": restaurant["location"],
+                        "Distance": round(restaurant["distance"] / 1609.34, ndigits=1),
+                        "Price": restaurant["price"],
+                        "Rating": restaurant["rating"]
+                    }
+
+        # We exhausted all the available restaurants or there were none at all
+        print("Could not find any restaurants with the given parameters!")
+        return {
+            "id": "N/A",
+            "Name": "No matches found!",
+            "Location": ('0', '0'),
+            "Distance": "I would walk 500",
+            "Price": "$$$$",
+            "Rating": 5
+        }
+
+    def cache_restaurant(self, user, restaurant_id):
+        """
+        Cache a restaurant that the user has recently rated so they don't receive it again
+        :param user: User that just rated this restaurant
+        :param restaurant_id: Yelp restaurant ID that was just rated
+        :return: None
+        """
+        self.cache.add_restaurant(user, restaurant_id)

--- a/backend/flaskr/recommender.py
+++ b/backend/flaskr/recommender.py
@@ -10,7 +10,9 @@ class Recommender:
 
     def __init__(self, cache_timeout=86400):
         """
-        Initializes restaurant cache and Yelp API to get suggestions and maintain which have been recently rated
+        Initializes restaurant cache and Yelp API to get suggestions and
+        maintain which restaurants have been recently rated.
+
         :param cache_timeout: Number of seconds to maintain stale restaurnt entries in cache
         :return: None
         """
@@ -29,7 +31,7 @@ class Recommender:
         distance = search_params["distance"]
         price = search_params["price"]
 
-        result = self.yelp.business_search(term=food, location=location, radius=distance, price=price)
+        result = self.yelp.business_search(food, location, distance, price)
 
         if "businesses" in result:
             for restaurant in result["businesses"]:

--- a/backend/tests/recommender/test_recommender.py
+++ b/backend/tests/recommender/test_recommender.py
@@ -1,0 +1,48 @@
+import pytest
+from backend.flaskr.recommender import Recommender
+
+
+def test_get_good_restaurant():
+    # Initialize recommender and test params
+    recommender = Recommender()
+    user = "Ben"
+    params = {
+        "food": "sushi",
+        "price": "$$",
+        "distance": "5",
+        "location": "(40.4167, -86.8753)"
+    }
+
+    # Ensure a restaurant is returned
+    result = recommender.get_restaurant(user, params)
+    assert result["Name"] != "No matches found!"
+
+def test_get_bad_restaurant():
+    # Initialize recommender and test params
+    recommender = Recommender()
+    user = "Ben"
+    params = {
+        "food": "bowl of nails without any milk",
+        "price": "$$",
+        "distance": "1",
+        "location": "(0, 0)"
+    }
+
+    # Ensure no recommendation is returned
+    result = recommender.get_restaurant(user, params)
+    assert result["Name"] == "No matches found!"
+
+def test_cache():
+    # Initialize recommender test params
+    recommender = Recommender()
+    user = "Ben"
+    ID = "1234"
+
+    # Ensure the recommender can cache the entry
+    assert not recommender.cache.is_cached(user, ID)
+    recommender.cache_restaurant(user, ID)
+    assert recommender.cache.is_cached(user, ID)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Refactor the recommendation logic out of app.py like we talked about earlier in the week.

This change also fixes the issue where we were caching the generated suggestions in the wrong spot. Now it properly caches them only after a suggestion is rated by the user.

Creating the separate class with unit tests also revealed a bug where I erroneously used `if result["businesses"]`, so it's good that we're catching this now.