### PR TITLE
Fix Frontend Authentication Issues

### DIFF
--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -38,7 +38,6 @@ function Login() {
 		event.preventDefault();
     
     attemptLogin(email, password).then(function(res){
-
       if (res === "/") {
         var CryptoJS = require("crypto-js");
         cookies.set('Username', email, { path: '/' });

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -17,6 +17,9 @@ export function attemptLogin(email, password) {
   }).then(response => response.json())
   .then(response => {
     path = response.result;
+    if (path === "/Login") {
+      alert("Invalid username or password.");
+    }
     return response.result;
   }).catch((error) => {
     console.error(error);

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -5,7 +5,7 @@ import Cookies from 'universal-cookie';
 import { useHistory } from "react-router-dom";
 
 export function attemptLogin(email, password) {
-  var path = "/";
+  var path = "/Login";
   return fetch("/cravr/login", {
     method: "POST",
     cache: "no-cache",
@@ -36,13 +36,15 @@ function Login() {
 
   function handleSubmit(event) {
 		event.preventDefault();
-   
-    var CryptoJS = require("crypto-js");
-    cookies.set('Username', email, { path: '/' });
-    cookies.set('Password', CryptoJS.AES.encrypt(password, 'CravrisCool').toString(), { path: '/' });
-    console.log(cookies.get('Password'));
     
     attemptLogin(email, password).then(function(res){
+
+      if (res === "/") {
+        var CryptoJS = require("crypto-js");
+        cookies.set('Username', email, { path: '/' });
+        cookies.set('Password', CryptoJS.AES.encrypt(password, 'CravrisCool').toString(), { path: '/' });
+        console.log(cookies.get('Password'));
+      }
       routeChange(res);
     });
   }

--- a/frontend/src/Register.js
+++ b/frontend/src/Register.js
@@ -24,10 +24,6 @@ export default function Register() {
 			return;
 		}
 
-		cookies.set('Username', email, { path: '/' });
-		cookies.set('Password', password, { path: '/' });
-		console.log(cookies.get('Username'));
-
 		fetch("/cravr/register", {
 			method: "POST",
 			cache: "no-cache",
@@ -39,6 +35,12 @@ export default function Register() {
 		.then(response => {
 			if (response.result === "/Login") {
 				attemptLogin(email, password).then(function(res){
+				    if (res === "/") {
+				        var CryptoJS = require("crypto-js");
+				        cookies.set('Username', email, { path: '/' });
+				        cookies.set('Password', CryptoJS.AES.encrypt(password, 'CravrisCool').toString(), { path: '/' });
+				        console.log(cookies.get('Password'));
+				    }
 					routeChange(res);
 				});
 			} else {


### PR DESCRIPTION
This PR fixes some bad frontend behavior when trying to login or register:

1. When the frontend cannot communicate with the backend (unsuccessful connection, backend not running, etc.), a user can login with any username/password combination (regardless of whether or not they are valid). The cookie is created without checking if authentication is successful, and the default redirect is "/". If a user logs in like this and then the backend comes back online, they will have successfully logged in without requiring the correct password.

2. When registering, cookies are created without checking if the new user is successfully added to the database. Additionally, these cookies are not encrypted.