### PR TITLE
Fix shallow clone issue when pushing to backend sbom

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - name: Create backend SBOM
         run: |
           pip install cyclonedx-bom

--- a/frontend/react-bom.json
+++ b/frontend/react-bom.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.2",
-  "serialNumber": "urn:uuid:aacc69b3-d323-4553-ac60-c5f66ccc91b2",
+  "serialNumber": "urn:uuid:81cd12aa-79c8-4b43-8efd-148934c0712f",
   "version": 1,
   "metadata": {
-    "timestamp": "2021-04-15T20:29:28.705Z",
+    "timestamp": "2021-04-15T20:41:38.439Z",
     "tools": [
       {
         "vendor": "CycloneDX",


### PR DESCRIPTION
This should (hopefully) fix issues as found [here ](https://github.com/bhgottfried/Cravr/pull/81/checks?check_run_id=2356588265) when updating the backend SBOM.